### PR TITLE
Avoid leading slashes when public path is empty

### DIFF
--- a/lib/SvgDocument.js
+++ b/lib/SvgDocument.js
@@ -91,11 +91,12 @@ class SvgDocument {
     getDimensions(scaleWidth, scaleHeight) {
         const viewBox = this.getViewBox();
         let rawWidth, rawHeight;
-        if (typeof viewBox == 'undefined') {
+        if (typeof viewBox === 'undefined') {
             // No viewBox is present. Get dimentions from viewport.
             rawWidth = this.getAttribute('width');
             rawHeight = this.getAttribute('height');
-        } else {
+        }
+        else {
             const parts = viewBox.split(' ');
             rawWidth = parts[2];
             rawHeight = parts[3];

--- a/lib/SvgIcon.js
+++ b/lib/SvgIcon.js
@@ -57,8 +57,10 @@ class SvgIcon {
      */
     getUrlToSymbol(publicPath) {
         publicPath = publicPath ? publicPath.replace(/\/+$/, '') : '';
-
-        return `${publicPath}/${this.sprite.resourcePath}#${this.symbolName}`;
+        if (publicPath.length > 0) {
+            publicPath += '/';
+        }
+        return `${publicPath}${this.sprite.resourcePath}#${this.symbolName}`;
     }
 
     /**
@@ -68,8 +70,11 @@ class SvgIcon {
      */
     getUrlToView(publicPath) {
         publicPath = publicPath ? publicPath.replace(/\/+$/, '') : '';
+        if (publicPath.length > 0) {
+            publicPath += '/';
+        }
 
-        return `${publicPath}/${this.sprite.resourcePath}#${this.viewName}`;
+        return `${publicPath}${this.sprite.resourcePath}#${this.viewName}`;
     }
 
 }


### PR DESCRIPTION
I had svg referenced from css as
```
url('../img/icon.svg')
```
which would get converted as
```
url('/sprite.svg#icon')
```
This leading slash would block image from rendering locally. And when rendered from server, it would confuse Safari.