### PR TITLE
Fix #22 Read width and height from respective attributes or viewbox

### DIFF
--- a/lib/SvgDocument.js
+++ b/lib/SvgDocument.js
@@ -89,12 +89,26 @@ class SvgDocument {
      * @returns {{height: number, width: number}}
      */
     getDimensions(scaleWidth, scaleHeight) {
+        let width, height;
+
         const viewBox = this.getViewBox();
 
-        const parts = viewBox.split(' ');
+        // If the view box attribute is not present then get the width and height attributes
+        if (typeof viewBox === 'undefined') {
+            width = this.getAttribute('width');
+            height = this.getAttribute('height');
+        }
 
-        let width = parseInt(parts[2]);
-        let height = parseInt(parts[3]);
+        // Otherwise, get the width and height from the viewbox.
+        else {
+            const parts = viewBox.split(' ');
+            width = parts[2];
+            height = parts[3];
+        }
+
+        // Convert both values to a number
+        width = Number(width);
+        height = Number(height);
 
         if (scaleHeight) {
             width = Math.round(((width * scaleHeight) / height) * 100) / 100;


### PR DESCRIPTION
* no longer assume a view box attribute is present (if not present read the width and height form their respective attributes)