### PR TITLE
Provide SVG title if one exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ class {
 
     render() {
         return (
-            <svg viewBox={logo.viewBox} title={logo.title}>
+            <svg viewBox={logo.viewBox} title={logo.title} role="img">
                 <use xlinkHref={logo.symbol} />
             </svg>
         );
     }
-    
+
 }
 ```
 
@@ -99,7 +99,7 @@ The imported value will be converted into the `view` url shown above.
 ```css
 .special-icon {
     /* the url will be replaced with the url to the sprite */
-    background-image: url('./icons/special.svg') no-repeat 0; 
+    background-image: url('./icons/special.svg') no-repeat 0;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ You will be able to import your SVG files in your JavaScript files as shown belo
 The imported SVG will always correspond to a JavaScript object with keys `symbol`, `view` and `viewBox`:
 - The `symbol` url can be used on a `<use>` tag to display the icon;
 - The `view` url is supposed to be used in CSS;
-- The `viewBox` value is required by some browsers on the `<svg>` tag.
+- The `viewBox` value is required by some browsers on the `<svg>` tag;
+- The `title` value can be used on the `<svg>` tag for accessibility.
 
 The URLs will have the following format:
 - `symbol`: `webpackConfig.output.publicPath`/`loader.name`#`loader.iconName`
@@ -73,7 +74,8 @@ The URLs will have the following format:
  * {
  *  symbol: '/public/img/sprite.svg#icon-logo',
  *  view: '/public/img/sprite.svg#view-icon-logo',
- *  viewBox: '0 0 150 100'
+ *  viewBox: '0 0 150 100',
+ *  title: 'Logo'
  * }
  */
 import logo from './images/logo.svg';
@@ -82,7 +84,7 @@ class {
 
     render() {
         return (
-            <svg viewBox={logo.viewBox}>
+            <svg viewBox={logo.viewBox} title={logo.title}>
                 <use xlinkHref={logo.symbol} />
             </svg>
         );

--- a/examples/images/code.svg
+++ b/examples/images/code.svg
@@ -3,6 +3,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="216px" height="146px" viewBox="0 0 216 146" enable-background="new 0 0 216 146" xml:space="preserve">
+	 <title>Code</title>
 	<g>
 		<path d="M126.413,18.575l-5.052-1.385c-0.651-0.217-1.291-0.149-1.914,0.204c-0.625,0.353-1.047,0.883-1.264,1.589l-30.39,105.182
 			c-0.217,0.706-0.149,1.372,0.204,1.996c0.353,0.625,0.882,1.046,1.589,1.263l5.051,1.385c0.652,0.219,1.29,0.151,1.915-0.203

--- a/examples/react/src/ExampleSVGIcon.jsx
+++ b/examples/react/src/ExampleSVGIcon.jsx
@@ -19,10 +19,10 @@ export default class ExampleSVGIcon extends Component {
                 <h1>Example SVG Icon</h1>
                 <p>This is an SVG icon rendered via SVG</p>
                 <div className={styles.icons}>
-                    <svg className={styles.icon} viewBox={codeIcon.viewBox} title={codeIcon.title}>
+                    <svg className={styles.icon} viewBox={codeIcon.viewBox} title={codeIcon.title} role="img">
                         <use xlinkHref={codeIcon.symbol} />
                     </svg>
-                    <svg className={styles.icon} viewBox={tailIcon.viewBox} title={tailIcon.title}>
+                    <svg className={styles.icon} viewBox={tailIcon.viewBox} role="presentation">
                         <use xlinkHref={tailIcon.symbol} />
                     </svg>
                 </div>

--- a/examples/react/src/ExampleSVGIcon.jsx
+++ b/examples/react/src/ExampleSVGIcon.jsx
@@ -19,10 +19,10 @@ export default class ExampleSVGIcon extends Component {
                 <h1>Example SVG Icon</h1>
                 <p>This is an SVG icon rendered via SVG</p>
                 <div className={styles.icons}>
-                    <svg className={styles.icon} viewBox={codeIcon.viewBox}>
+                    <svg className={styles.icon} viewBox={codeIcon.viewBox} title={codeIcon.title}>
                         <use xlinkHref={codeIcon.symbol} />
                     </svg>
-                    <svg className={styles.icon} viewBox={tailIcon.viewBox}>
+                    <svg className={styles.icon} viewBox={tailIcon.viewBox} title={tailIcon.title}>
                         <use xlinkHref={tailIcon.symbol} />
                     </svg>
                 </div>

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ const DEFAULT_QUERY_VALUES = {
             { convertTransform: true },
             { removeDesc: true },
             { removeDimensions: true },
-            { removeTitle: true },
         ],
     },
 };
@@ -71,6 +70,7 @@ function loader(content) {
                     symbol: publicPath + '${icon.getUrlToSymbol()}',
                     view: publicPath + '${icon.getUrlToView()}',
                     viewBox: '${icon.getDocument().getViewBox()}',
+                    title: '${icon.getDocument().getTitle()}',
                     toString: function () {
                         return JSON.stringify(this.view);
                     }

--- a/lib/SvgDocument.js
+++ b/lib/SvgDocument.js
@@ -131,6 +131,14 @@ class SvgDocument {
         return this.getAttribute('viewBox');
     }
 
+    /**
+     * Gets the title.
+     * @returns {string}
+     */
+    getTitle() {
+        return this.$svg.find('title').text();
+    }
+
     load(content) {
         return cheerio.load(content, { normalizeWhitespace: true, xmlMode: true });
     }


### PR DESCRIPTION
According to https://github.com/jonathantneal/svg4everybody#readability-and-accessibility:

> All together, use the title attribute in your document and the title element in your SVG.

This change provides the SVG title so it can be used in the markup.