### PR TITLE
Fix for when ExtractedModule is null

### DIFF
--- a/lib/SvgStorePlugin.js
+++ b/lib/SvgStorePlugin.js
@@ -13,6 +13,15 @@ catch (e) {
     ExtractedModule = null;
 }
 
+if (!ExtractedModule) {
+  try {
+    ExtractedModule = require('extract-text-webpack-plugin/dist/lib/ExtractedModule').default;
+  }
+  catch (e) {
+    ExtractedModule = null;
+  }
+}
+
 const _emit = Symbol();
 
 /**


### PR DESCRIPTION
Fix for issue https://github.com/karify/external-svg-sprite-loader/issues/33