### PR TITLE
Fix possible unhandled rejection if webpack's loader chain throws sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,22 +63,24 @@ function loader(content) {
             const icon = SvgStorePlugin.getSprite(query.name).addIcon(resourcePath, iconName, content.toString());
 
             // Export the icon as a metadata object that contains urls to be used on an <img/> in HTML or url() in CSS
-            callback(
-                null,
-                `var publicPath = ${query.publicPath ? `'${query.publicPath}'` : '__webpack_public_path__' };
-                module.exports = {
-                    symbol: publicPath + '${icon.getUrlToSymbol()}',
-                    view: publicPath + '${icon.getUrlToView()}',
-                    viewBox: '${icon.getDocument().getViewBox()}',
-                    title: '${icon.getDocument().getTitle()}',
-                    toString: function () {
-                        return JSON.stringify(this.view);
-                    }
-                };`
-            );
+            setImmediate(() => {
+                callback(
+                    null,
+                    `var publicPath = ${query.publicPath ? `'${query.publicPath}'` : '__webpack_public_path__' };
+                    module.exports = {
+                        symbol: publicPath + '${icon.getUrlToSymbol()}',
+                        view: publicPath + '${icon.getUrlToView()}',
+                        viewBox: '${icon.getDocument().getViewBox()}',
+                        title: '${icon.getDocument().getTitle()}',
+                        toString: function () {
+                            return JSON.stringify(this.view);
+                        }
+                    };`
+                );
+            });
         })
         .catch((err) => {
-            callback(err);
+            setImmediate(() => callback(err));
         });
 }
 


### PR DESCRIPTION
```js
function doSomething(callback) {
   thisReturnsAPromise()
   .then(callback, callback);
}

doSomething(() => {
    // throw an error explicitly but could be an implicit error, such as accessing a property of null
    throw new Error();
});
```

The code above does not terminate the process with a uncaught exception. Instead it will print an unhandled promise error.
The loader code has the same pattern. This MR fixes that.
