### PR TITLE
Disable `removeViewBox` plugin in default svgo options

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const DEFAULT_QUERY_VALUES = {
             { convertStyleToAttrs: true },
             { convertTransform: true },
             { removeDesc: true },
+            { removeViewBox: false },
             { removeDimensions: true },
         ],
     },


### PR DESCRIPTION
In the most recent version of svgo that we are now using, `removeViewBox` is enabled by default: https://github.com/svg/svgo/commit/055e303607d53a3d539761d8727d86c03b2e88c1

This is something that we don't want by default.