### PR TITLE
Fix multiple compilations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn add external-svg-sprite-loader
 ### Plugin options
 
 - `emit` - determines if the sprite is supposed to be emitted (default: true). Useful when generating server rendering bundles where you just need the SVG sprite URLs but not the sprite itself.
-- `sprite` - SVG sprite options (default: {startX: 0, startY: 0, deltaX: 0, deltaY: 0, iconHeight: 50}). StartX and StartY - beginning sprite position, DeltaX and DeltaY - free space between icons. IconHeight - Icon height in the sprite (just for the comfort)
+- `sprite` - SVG sprite options (default: {startX: 0, startY: 0, deltaX: 0, deltaY: 0, iconHeight: 50, rowWidth: 1000}). StartX and StartY - beginning sprite position, DeltaX and DeltaY - space between icons. IconHeight - Icon height in the sprite (just for the comfort).
 
 ## Usage
 
@@ -53,7 +53,7 @@ module.exports = {
     module: {
         rules: [
             {
-                loader: 'external-svg-sprite-loader',
+                loader: SvgStorePlugin.loader,
                 test: /\.svg$/,
             },
         ],
@@ -115,7 +115,7 @@ The imported value will be converted into the `view` url shown above.
 }
 ```
 
-When a SVG gets added, removed or updated, the sprite will be re-generated and all files referencing it will be updated. When no `[hash]` is used in the `name` option, a cache-busting will be added to the URL so that the browser is forced to re-download the sprite.
+When a SVG is added, removed or changed, the sprite will be re-generated and all files referencing it will be updated. When no `[hash]` is used in the `name` option, a cache-busting will be added to the URL so that the browser is forced to re-download the sprite.
 
 ## Examples
 

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -41,7 +41,8 @@
     "start:dev:no-hash": "EXAMPLE_NO_HASH=1 yarn start:dev",
     "start:dev:hot-no-hash": "EXAMPLE_NO_HASH=1 yarn start:dev:hot",
     "start:prd": "NODE_ENV=production node server/build/js/main.js",
-    "build:prd": "NODE_ENV=production webpack -p"
+    "build:prd": "NODE_ENV=production webpack -p",
+    "build:clean": "rm -rf public/build && rm -rf server/build"
   },
   "version": "3.4.0"
 }

--- a/examples/react/src/index.server.jsx
+++ b/examples/react/src/index.server.jsx
@@ -15,7 +15,7 @@ app.use(express.static('public', {
 app.get('*', (request, response) => {
     const content = renderToString(<App />);
 
-    fs.readFile('public/index.html', (err, document) => {
+    fs.readFile('public/index.html', 'utf8', (err, document) => {
         response.send(document.replace('<div id="root"></div>', `<div id="root">${content}</div>`));
     });
 });

--- a/examples/react/webpack.config.js
+++ b/examples/react/webpack.config.js
@@ -2,9 +2,9 @@ const path = require('path');
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const SvgStorePlugin = require('../../lib/SvgStorePlugin');
+const SvgStorePlugin = require('../..');
 
-const create = () => ({
+const create = ({ emit }) => ({
     mode: process.env.NODE_ENV,
     module: {
         rules: [
@@ -27,7 +27,7 @@ const create = () => ({
                 test: /\.css$/,
             },
             ...['complex', 'education', 'glypho'].map((value) => ({
-                loader: require.resolve('../..'),
+                loader: SvgStorePlugin.loader,
                 options: {
                     name: process.env.EXAMPLE_NO_HASH ? `img/${value}.svg` : `img/${value}.[hash].svg`,
                 },
@@ -53,6 +53,7 @@ const create = () => ({
             chunkFilename: 'css/[id].css',
         }),
         new SvgStorePlugin({
+            emit,
             sprite: {
                 startX: 20,
                 startY: 10,
@@ -64,7 +65,7 @@ const create = () => ({
 });
 
 const configs = [
-    Object.assign(create(), {
+    Object.assign(create({ emit: true }), {
         entry: {
             main: path.join(__dirname, 'src', 'index.client.jsx'),
         },
@@ -79,7 +80,7 @@ const configs = [
 
 if (process.env.NODE_ENV === 'production') {
     configs.push(
-        Object.assign(create(), {
+        Object.assign(create({ emit: false }), {
             entry: {
                 main: path.join(__dirname, 'src', 'index.server.jsx'),
             },

--- a/lib/SvgIcon.js
+++ b/lib/SvgIcon.js
@@ -50,7 +50,7 @@ class SvgIcon {
      * @param {boolean} addCacheBust - true to add a cache bust to force the re-download of the sprite
      * @returns {string}
      */
-    getUrlToSymbol(addCacheBust) {
+    getUrlToSymbol(addCacheBust = false) {
         return this.getSpriteUrl(addCacheBust) + '#' + this.symbolName;
     }
 
@@ -59,7 +59,7 @@ class SvgIcon {
      * @param {boolean} addCacheBust - true to add a cache bust to force the re-download of the sprite
      * @returns {string}
      */
-    getUrlToView(addCacheBust) {
+    getUrlToView(addCacheBust = false) {
         return this.getSpriteUrl(addCacheBust) + '#' + this.viewName;
     }
 

--- a/lib/SvgSprite.js
+++ b/lib/SvgSprite.js
@@ -9,28 +9,6 @@ const SvgDocument = require('./SvgDocument');
 const SvgIcon = require('./SvgIcon');
 
 /**
- * Default icon height in the sprite.
- * - All icons are resized based on this height.
- * @const
- * @memberOf SvgSprite
- * @private
- * @static
- * @type {number}
- */
-const DEFAULT_ICON_HEIGHT = 50;
-
-/**
- * Max row width in a sprite.
- * - This value is used to determine if an icon can stay in the current row or if it must be placed in the next.
- * @const
- * @memberOf SvgSprite
- * @private
- * @static
- * @type {number}
- */
-const MAX_ROW_WIDTH = 1000;
-
-/**
  * SVG Sprite
  */
 class SvgSprite {
@@ -47,22 +25,22 @@ class SvgSprite {
         this.content = '';
         /** @member {string} */
         this.name = name;
-        /** @member {string} */
+        /** @member {string} the resource path given in the configuration */
         this.originalResourcePath = resourcePath;
         /** @member {RegExp} */
         this.originalResourcePathRegExp = resourcePathRegExp;
-        /** @member {?string} */
+        /** @member {?string} the interpolated resource path for the previous compilation */
         this.previousResourcePath = null;
         /** @member {?RegExp} */
         this.previousResourcePathRegExp = null;
-        /** @member {string} */
+        /** @member {string} the interpolated resource path for the current compilation */
         this.resourcePath = resourcePath;
         /** @member {RegExp} */
         this.resourcePathRegExp = resourcePathRegExp;
         /** @member {Object.<string, SvgIcon>} */
         this.icons = {};
         /** @member {boolean} */
-        this.updated = false;
+        this.changed = false;
         /** @member {boolean} */
         this.dirty = false;
     }
@@ -90,7 +68,8 @@ class SvgSprite {
      * @param {number} options.startY - sprite start Y position.
      * @param {number} options.deltaX - free space between icons by X.
      * @param {number} options.deltaY - free space between icons by Y.
-     * @param {number} options.iconHeight - Icon height in the sprite - All icons are resized based on this height.
+     * @param {number} options.iconHeight - height to which icons will be resized to.
+     * @param {number} options.rowWidth - used to determine if an icon can stay in the current row or if it must be placed in the next.
      * @return {string}
      */
     generate({
@@ -98,10 +77,11 @@ class SvgSprite {
         startY = 0,
         deltaX = 0,
         deltaY = 0,
-        iconHeight = DEFAULT_ICON_HEIGHT,
-    } = {}) {
+        iconHeight = 50,
+        rowWidth = 1000,
+    }) {
         if (!this.dirty) {
-            this.updated = false;
+            this.changed = false;
 
             return this.content;
         }
@@ -157,7 +137,7 @@ class SvgSprite {
             x = x + (iconHeight * Math.ceil(width / iconHeight)) + deltaX;
 
             // If x exceeds the max row width, then move to the next line and reset the value of x
-            if (x + width > startX + MAX_ROW_WIDTH) {
+            if (x + width > startX + rowWidth) {
                 x = startX;
                 y += iconHeight + deltaY;
             }
@@ -188,9 +168,9 @@ class SvgSprite {
         this.resourcePathRegExp = new RegExp(escapeRegExp(resourcePath), 'gm');
         this.content = content;
 
-        // Mark the sprite as updated without any changes
+        // Mark the sprite as changed and not dirty since all changes were now applied
+        this.changed = true;
         this.dirty = false;
-        this.updated = true;
 
         return content;
     }
@@ -204,9 +184,9 @@ class SvgSprite {
         const { resourcePath, previousResourcePath, originalResourcePathRegExp, previousResourcePathRegExp } = this;
 
         // Always replace the `originalResourcePath`
-        // Moreover, replace the `previousResourcePath` with the new one if they are different
         source = source.replace(originalResourcePathRegExp, resourcePath);
 
+        // Moreover, replace the `previousResourcePath` with the new one if they are different
         if (resourcePath !== previousResourcePath) {
             source = source.replace(previousResourcePathRegExp, resourcePath);
         }

--- a/lib/SvgStorePlugin.js
+++ b/lib/SvgStorePlugin.js
@@ -3,16 +3,19 @@
 const Chunk = require('webpack/lib/Chunk');
 
 const MissingDimensionsException = require('./exceptions/MissingDimensionsException');
+const { DEFAULT_LOADER_OPTIONS } = require('./loader');
 const SvgSprite = require('./SvgSprite');
 
 /**
- * Stores the sprites to be generated and the icons to be included on each one.
- * @memberOf SvgStorePlugin
- * @private
- * @static
- * @type {Object.<string, SvgSprite>}
+ * @property {boolean} emit - determines if sprites must be emitted.
+ * @property {string} filename
+ * @property {{ startX: number, startY: number, deltaX: number, deltaY: number, iconHeight: number, rowWidth: number }} sprite - positioning and sizing options for the symbols in a sprite.
+ * @type {Readonly<{emit: boolean, filename: string, sprite: Readonly<{}>}>}
  */
-const store = {};
+const DEFAULT_PLUGIN_OPTIONS = Object.freeze({
+    emit: true,
+    sprite: Object.freeze({}),
+});
 
 /**
  * SVG Store Plugin
@@ -25,39 +28,29 @@ class SvgStorePlugin {
     /**
      * Initializes options.
      * @param {Object} options
-     * @param {boolean} options.emit - determines if sprites must be emitted.
-     * @param {{ startX: number, startY: number, deltaX: number, deltaY: number, iconHeight: number }} options.sprite - positioning and sizing options for the symbols in the sprite.
      */
-    constructor({
-        emit = true,
-        sprite = {},
-    } = {}) {
-        /** @member {boolean} */
-        this.emit = emit;
-        /** @member {{ startX: number, startY: number, deltaX: number, deltaY: number, iconHeight: number }} */
-        this.sprite = sprite;
+    constructor(options) {
+        /** @member {Object} */
+        this.options = Object.assign({}, DEFAULT_PLUGIN_OPTIONS, options);
+        /** @member {SvgSprite[]} */
+        this.sprites = [];
     }
 
     /**
-     * Gets the sprite instance for the given path or if it doesn't exist creates a new one.
-     * @param {string} resourcePath - the relative path for the sprite based on the output folder.
-     * @returns {SvgSprite}
-     */
-    static getSprite(resourcePath) {
-        if (!(resourcePath in store)) {
-            store[resourcePath] = new SvgSprite(resourcePath);
-        }
-
-        return store[resourcePath];
-    }
-
-    /**
+     * Injects a sprite for each loader in the configuration so that they can add icons to a sprite.
      * Attaches the compilation process to the current compilation.
      * @param {webpack.Compiler} compiler
      */
     apply(compiler) {
         /** @type {{ thisCompilation: Tapable }} */
         const { hooks } = compiler;
+
+        const { rules } = compiler.options.module;
+
+        /**
+         * Iterates through the given list of rules and injects a sprite for each rule that uses our loader.
+         {Object[]}    */
+        this.injectSpritesIntoRules(rules);
 
         hooks.thisCompilation.tap(this.constructor.name, this.exec.bind(this));
     }
@@ -71,6 +64,8 @@ class SvgStorePlugin {
      * @param {webpack.Compilation} compilation
      */
     exec(compilation) {
+        const { options } = this;
+
         /** @type {{ optimize: Tapable, optimizeModules: Tapable, additionalAssets: Tapable }} */
         const { hooks } = compilation;
 
@@ -81,7 +76,7 @@ class SvgStorePlugin {
         hooks.optimizeChunks.tap(this.constructor.name, this.fixSpritePathsInChunks.bind(this));
 
         // Add sprites to the compilation assets
-        if (this.emit) {
+        if (options.emit) {
             hooks.additionalAssets.tapAsync(this.constructor.name, this.registerSprites.bind(this, compilation));
         }
 
@@ -95,11 +90,6 @@ class SvgStorePlugin {
         const spritesWithInterpolatedName = this.getSpritesWithInterpolateName();
 
         for (const sprite of spritesWithInterpolatedName) {
-            // Skip it if it wasn't updated
-            if (!sprite.updated) {
-                continue;
-            }
-
             for (const chunk of chunks) {
                 for (const module of chunk.modulesIterable) {
                     this.replaceSpritePathsInModuleWithInterpolatedPaths(module, sprite);
@@ -113,9 +103,11 @@ class SvgStorePlugin {
      * Generates the content for every sprite.
      */
     generateSprites(compilation) {
-        for (const spritePath in store) {
+        const { options, sprites } = this;
+
+        for (const sprite of sprites) {
             try {
-                store[spritePath].generate(this.sprite);
+                sprite.generate(options.sprite);
             } catch (error) {
                 if (error instanceof MissingDimensionsException) {
                     compilation.warnings.push(error);
@@ -127,22 +119,15 @@ class SvgStorePlugin {
     }
 
     /**
-     * Gets the underlying sprites store.
-     * @returns {Object.<string, SvgSprite>}
-     */
-    getStore() {
-        return store;
-    }
-
-    /**
      * Gets sprites which name have an hash.
      * @returns {SvgSprite[]}
      */
     getSpritesWithInterpolateName() {
+        const { sprites } = this;
+
         const spritesWithInterpolatedName = [];
 
-        for (const spritePath in store) {
-            const sprite = store[spritePath];
+        for (const sprite of sprites) {
             const { originalResourcePath, resourcePath } = sprite;
 
             if (originalResourcePath !== resourcePath) {
@@ -151,6 +136,46 @@ class SvgStorePlugin {
         }
 
         return spritesWithInterpolatedName;
+    }
+
+    /**
+     * Injects a sprite into the given rule options so that the loader can add icons to the sprite.
+     * @param {Object} rule
+     */
+    injectSpriteIntoRule(rule) {
+        const { sprites } = this;
+
+        if (!('options' in rule)) {
+            rule.options = {};
+        }
+
+        // Get the sprite resource path either from the rule options or the default options
+        const resourcePath = rule.options.name || DEFAULT_LOADER_OPTIONS.name;
+
+        // Initialize the sprite
+        const sprite = new SvgSprite(resourcePath);
+
+        // Inject sprite into loader options
+        rule.options.sprite = sprite;
+
+        // Add sprite to the list of sprites
+        sprites.push(sprite);
+    }
+
+    /**
+     * Iterates through the given list of rules and injects a sprite for each rule that uses our loader.
+     * @param {Object[]} rules
+     */
+    injectSpritesIntoRules(rules) {
+        for (const rule of rules) {
+            const subRules = rule.use || rule.loaders || [rule];
+
+            for (const subRule of subRules) {
+                if (subRule.loader === SvgStorePlugin.loader) {
+                    this.injectSpriteIntoRule(subRule);
+                }
+            }
+        }
     }
 
     /**
@@ -165,6 +190,11 @@ class SvgStorePlugin {
                 break;
 
             case 'NormalModule': {
+                // Skip it if it wasn't changed
+                if (!sprite.changed) {
+                    return;
+                }
+
                 const source = module._source;
 
                 if (typeof source === 'string') {
@@ -188,12 +218,14 @@ class SvgStorePlugin {
      * @param {Function} callback
      */
     registerSprites(compilation, callback) {
-        for (const spritePath in store) {
-            const { name, resourcePath, content, updated } = store[spritePath];
+        const { sprites } = this;
+
+        for (const sprite of sprites) {
+            const { changed, content, name, resourcePath } = sprite;
 
             // If the sprite wasn't changed since the last compilation
             // then skip this step because the assets were already generated before
-            if (!updated) {
+            if (!changed) {
                 continue;
             }
 
@@ -222,5 +254,7 @@ class SvgStorePlugin {
     }
 
 }
+
+SvgStorePlugin.loader = require.resolve('./loader');
 
 module.exports = SvgStorePlugin;

--- a/lib/SvgStorePlugin.js
+++ b/lib/SvgStorePlugin.js
@@ -47,9 +47,7 @@ class SvgStorePlugin {
 
         const { rules } = compiler.options.module;
 
-        /**
-         * Iterates through the given list of rules and injects a sprite for each rule that uses our loader.
-         {Object[]}    */
+        // Iterates through the given list of rules and injects a sprite for each rule that uses our loader.
         this.injectSpritesIntoRules(rules);
 
         hooks.thisCompilation.tap(this.constructor.name, this.exec.bind(this));
@@ -165,15 +163,29 @@ class SvgStorePlugin {
     /**
      * Iterates through the given list of rules and injects a sprite for each rule that uses our loader.
      * @param {Object[]} rules
+     * @see https://webpack.js.org/configuration/module/#rule-loader
+     * @see https://webpack.js.org/configuration/module/#rule-oneof
+     * @see https://webpack.js.org/configuration/module/#rule-rules
+     * @see https://webpack.js.org/configuration/module/#rule-use
      */
     injectSpritesIntoRules(rules) {
         for (const rule of rules) {
-            const subRules = rule.use || rule.loaders || [rule];
+            const { oneOf: oneOfRules, rules: subRules, use: ruleUse } = rule;
 
-            for (const subRule of subRules) {
+            const loaders = ruleUse || [rule];
+
+            for (const subRule of loaders) {
                 if (subRule.loader === SvgStorePlugin.loader) {
                     this.injectSpriteIntoRule(subRule);
                 }
+            }
+
+            if (subRules) {
+                this.injectSpritesIntoRules(subRules);
+            }
+
+            if (oneOfRules) {
+                this.injectSpritesIntoRules(oneOfRules);
             }
         }
     }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,14 +4,12 @@ const imagemin = require('imagemin');
 const imageminSvgo = require('imagemin-svgo');
 const loaderUtils = require('loader-utils');
 
-const SvgStorePlugin = require('./lib/SvgStorePlugin');
-
 /**
  * Default values for every param that can be passed in the loader options.
  * @const
  * @type {Object}
  */
-const DEFAULT_OPTIONS = Object.freeze({
+const DEFAULT_LOADER_OPTIONS = Object.freeze({
     name: 'img/sprite.svg',
     iconName: 'icon-[name]-[hash:5]',
     svgoOptions: Object.freeze({
@@ -29,7 +27,7 @@ const DEFAULT_OPTIONS = Object.freeze({
 
 /**
  * Applies SVGO on the SVG file in order to optimize its contents and remove unnecessary attributes for the sprite.
- * Registers the SVG on the Sprites store so that the plugin has access to them.
+ * Adds the SVG to the given sprite which will then be processed by the plugin.
  * Generates SVG metadata to be passed to JavaScript and CSS files so that the symbols can be rendered.
  * @param {Buffer} content - the content of the SVG file.
  */
@@ -40,10 +38,7 @@ function loader(content) {
     const callback = this.async();
 
     // Parse the loader query and apply the default values in case no values are provided
-    const options = Object.assign({}, DEFAULT_OPTIONS, loaderUtils.getOptions(this));
-
-    // Get the sprite
-    const sprite = SvgStorePlugin.getSprite(options.name);
+    const { iconName, publicPath, sprite, svgoOptions } = Object.assign({}, DEFAULT_LOADER_OPTIONS, loaderUtils.getOptions(this));
 
     // Add the icon as a dependency
     addDependency(resourcePath);
@@ -52,16 +47,16 @@ function loader(content) {
     imagemin
         .buffer(content, {
             plugins: [
-                imageminSvgo(options.svgoOptions),
+                imageminSvgo(svgoOptions),
             ],
         })
         .then((content) => {
 
             // Create the icon name with the hash of the optimized content
-            const iconName = loaderUtils.interpolateName(this, options.iconName, { content });
+            const name = loaderUtils.interpolateName(this, iconName, { content });
 
             // Register the sprite and icon
-            const icon = sprite.addIcon(resourcePath, iconName, content.toString());
+            const icon = sprite.addIcon(resourcePath, name, content.toString());
 
             // Export the icon as a metadata object that contains urls to be used on an <img/> in HTML or url() in CSS
             // If the outputted file is not hashed and to support hot module reload, we must force the browser
@@ -74,7 +69,7 @@ function loader(content) {
             setImmediate(() => {
                 callback(
                     null,
-                    `var publicPath = ${options.publicPath ? `'${options.publicPath}'` : '__webpack_public_path__'};
+                    `var publicPath = ${publicPath ? `'${publicPath}'` : '__webpack_public_path__'};
                     var symbolUrl = '${icon.getUrlToSymbol()}';
                     var viewUrl = '${icon.getUrlToView()}';
 
@@ -104,6 +99,8 @@ function loader(content) {
         });
 }
 
-loader.raw = true;
-
-module.exports = loader;
+module.exports = {
+    default: loader,
+    DEFAULT_LOADER_OPTIONS,
+    raw: true,
+};

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "url": "http://github.com/Karify/external-svg-sprite-loader.git"
   },
   "scripts": {
-    "lint": "eslint index.js lib examples --ext=js,jsx"
+    "lint": "eslint lib examples --ext=js,jsx"
   },
   "version": "4.0.0-beta.6"
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "npm": ">=3.8.0"
   },
   "files": [
-    "lib",
-    "index.js"
+    "lib"
   ],
   "keywords": [
     "svg",
@@ -41,7 +40,7 @@
     "webpack-loader"
   ],
   "license": "MIT",
-  "main": "index.js",
+  "main": "lib/SvgStorePlugin.js",
   "name": "external-svg-sprite-loader",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Make the loader a property of the plugin so that it becomes clear the plugin and loader belong together (this is also similar to what other plugins do)
* Move the loader into the lib folder
* Change the main export of this package to the plugin
* Remove the global store and instead inject sprites into the loaders as an option. In this way, there are no shared sprites across compilations.
* Update the README with the changes mentioned above