### PR TITLE
Use the icon resource path with query as id

### DIFF
--- a/lib/SvgSprite.js
+++ b/lib/SvgSprite.js
@@ -47,14 +47,14 @@ class SvgSprite {
 
     /**
      * Adds an icon to the sprite and sets the sprite to dirty so that new changes can be detected.
-     * @param {string} resourcePath - the icon absolute path.
-     * @param {string} name - the icon name.
+     * @param {string} id - the icon absolute path including query.
+     * @param {string} name - the interpolated icon name.
      * @param {string} content - the icon content.
      * @returns {SvgIcon}
      */
-    addIcon(resourcePath, name, content) {
-        const icons = this.icons;
-        const icon = icons[resourcePath] = new SvgIcon(this, name, content);
+    addIcon(id, name, content) {
+        const { icons } = this;
+        const icon = icons[id] = new SvgIcon(this, name, content);
 
         this.dirty = true;
 
@@ -101,11 +101,11 @@ class SvgSprite {
         let y = startY;
 
         // For every icon in the sprite
-        for (const iconPath of iconsSorted) {
+        for (const id of iconsSorted) {
 
             // Get the icon metadata
             /** @type {SvgIcon} */
-            const icon = icons[iconPath];
+            const icon = icons[id];
 
             // Create an SVG Document out of the icon contents
             const svg = icon.getDocument();

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -32,7 +32,7 @@ const DEFAULT_LOADER_OPTIONS = Object.freeze({
  * @param {Buffer} content - the content of the SVG file.
  */
 function loader(content) {
-    const { addDependency, resourcePath } = this;
+    const { addDependency, resource, resourcePath } = this;
 
     // Get callback because the SVG is going to be optimized and that is an async operation
     const callback = this.async();
@@ -55,8 +55,9 @@ function loader(content) {
             // Create the icon name with the hash of the optimized content
             const name = loaderUtils.interpolateName(this, iconName, { content });
 
-            // Register the sprite and icon
-            const icon = sprite.addIcon(resourcePath, name, content.toString());
+            // Register the icon using its resource path with query as id
+            // so that tools like: `svg-transform-loader` can be used in combination with this loader.
+            const icon = sprite.addIcon(resource, name, content.toString());
 
             // Export the icon as a metadata object that contains urls to be used on an <img/> in HTML or url() in CSS
             // If the outputted file is not hashed and to support hot module reload, we must force the browser


### PR DESCRIPTION
* In this way the same icon can be added multiple times with different properties (example: when using tools like `svg-transform-loader`)